### PR TITLE
Migrate from `dart:js_utils` and `package:js` to `dart:js_interop` for Web platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ application to call the native Fingerprint Pro libraries (Android, iOS and Web) 
 
 ## Requirements
 - Flutter 3.10 or higher
+- Dart 3.3 or higher
 - Android 5.0 (API level 21+) or higher
 - iOS 13+/tvOS 15+, Swift 5.7 or higher (stable releases)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ application to call the native Fingerprint Pro libraries (Android, iOS and Web) 
 * [License](#license)
 
 ## Requirements
-- Flutter 3.10 or higher
+- Flutter 3.13 or higher
 - Dart 3.3 or higher
 - Android 5.0 (API level 21+) or higher
 - iOS 13+/tvOS 15+, Swift 5.7 or higher (stable releases)

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -95,30 +95,22 @@ packages:
       relative: true
     source: path
     version: "3.3.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.1"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -171,7 +163,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -184,10 +176,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -200,10 +192,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
@@ -216,10 +208,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   vector_math:
     dependency: transitive
     description:
@@ -232,10 +224,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.0"
 sdks:
   dart: ">=3.5.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/js_agent_interop.dart
+++ b/lib/js_agent_interop.dart
@@ -4,13 +4,13 @@
 @JS('FingerprintJSFlutter')
 library fingerprint_js;
 
-import 'package:js/js.dart';
+import 'dart:js_interop';
 
 /// FingerprintJS Pro library namespace
-@JS('FingerprintJS')
-class FingerprintJS {
+extension type FingerprintJS._(JSObject _) implements JSObject {
   /// Loads JS Agent script to the webpage and initialize it
-  external static Future<FingerprintJSAgent> load(FingerprintJSOptions options);
+  external static JSPromise<FingerprintJSAgent> load(
+      FingerprintJSOptions options);
   external static String get ERROR_NETWORK_CONNECTION;
   external static String get ERROR_NETWORK_ABORT;
   external static String get ERROR_API_KEY_MISSING;
@@ -35,21 +35,17 @@ class FingerprintJS {
 }
 
 /// FingerprintJS Pro [JavaScript agent](https://dev.fingerprint.com/docs/js-agent)
-@JS()
-@anonymous
-class FingerprintJSAgent {
+extension type FingerprintJSAgent._(JSObject _) implements JSObject {
   /// Gets the visitor identifier.
   /// When an error is emitted by the backend, it gets a `requestId` field, same as in successful result.
-  external Future<IdentificationResult> get(FingerprintJSGetOptions options);
+  external JSPromise<IdentificationResult> get(FingerprintJSGetOptions options);
 }
 
 /// Result of getting a visitor id.
 ///
 /// `visitorId` can be empty string when the visitor can't be identified.
 /// It happens only with bots and hackers that modify their browsers.
-@JS()
-@anonymous
-class IdentificationResult {
+extension type IdentificationResult._(JSObject _) implements JSObject {
   /// The visitor identifier
   external String visitorId;
 
@@ -69,9 +65,8 @@ class IdentificationResult {
 }
 
 /// Result of requesting a visitor id when requested with `extendedResponseFormat: true`
-@JS()
-@anonymous
-class IdentificationExtendedResult extends IdentificationResult {
+extension type IdentificationExtendedResult._(IdentificationResult _)
+    implements IdentificationResult {
   /// Whether the visitor is in incognito/private mode
   external bool incognito;
 
@@ -105,9 +100,8 @@ class IdentificationExtendedResult extends IdentificationResult {
 }
 
 /// A confidence score that tells how much the agent is sure about the visitor identifier
-@JS()
-@anonymous
-class IdentificationResultConfidenceScore {
+extension type IdentificationResultConfidenceScore._(JSObject _)
+    implements JSObject {
   /// A number between 0 and 1 that tells how much the agent is sure about the visitor identifier.
   /// The higher the number, the higher the chance of the visitor identifier to be true.
   external num score;
@@ -117,9 +111,8 @@ class IdentificationResultConfidenceScore {
 }
 
 /// IP address location. Can be empty for anonymous proxies.
-@JS()
-@anonymous
-class IdentificationResultIpLocation {
+extension type IdentificationResultIpLocation._(JSObject _)
+    implements JSObject {
   /// IP address location detection radius. Smaller values (<50mi) are business/residential,
   /// medium values (50 < x < 500) are cellular towers (usually),
   /// larger values (>= 500) are cloud IPs or proxies, VPNs.
@@ -152,45 +145,36 @@ class IdentificationResultIpLocation {
   /// Administrative subdivisions array (for example states|provinces -> counties|parishes).
   /// Can be empty or missing.
   /// When not empty, can contain only top-level administrative units within a country, e.g. a state.
-  external List<IdentificationResultSubdivision>? subdivisions;
+  external JSArray<IdentificationResultSubdivision>? subdivisions;
 }
 
 /// City, when available
-@JS()
-@anonymous
-class IdentificationResultCity {
+extension type IdentificationResultCity._(JSObject _) implements JSObject {
   external String name;
 }
 
 /// Country, when available. Will be missing for Tor/anonymous proxies.
-@JS()
-@anonymous
-class IdentificationResultCountry {
+extension type IdentificationResultCountry._(JSObject _) implements JSObject {
   external String code;
   external String name;
 }
 
 /// Continent, when available. Will be missing for Tor/anonymous proxies.
-@JS()
-@anonymous
-class IdentificationResultContinent {
+extension type IdentificationResultContinent._(JSObject _) implements JSObject {
   external String code;
   external String name;
 }
 
 /// Administrative subdivision (for example states|provinces -> counties|parishes).
 /// Can contain only top-level administrative units within a country, e.g. a state.
-@JS()
-@anonymous
-class IdentificationResultSubdivision {
+extension type IdentificationResultSubdivision._(JSObject _)
+    implements JSObject {
   external String isoCode;
   external String name;
 }
 
 /// When the visitor was seen
-@JS()
-@anonymous
-class IdentificationResultStSeenAt {
+extension type IdentificationResultStSeenAt._(JSObject _) implements JSObject {
   /// The date and time across all subscription. The string format is ISO-8601.
   external String? global;
 
@@ -199,24 +183,22 @@ class IdentificationResultStSeenAt {
 }
 
 /// Options that need to load JS Agent
-@JS()
-@anonymous
-class FingerprintJSOptions {
+extension type FingerprintJSOptions._(JSObject _) implements JSObject {
   /// Public API key
   external String get apiKey;
 
   /// Information about libraries and services used to integrate the JS agent.
   /// Each array item means a separate integration, the order doesn't matter.
   /// An example of an integration library is FingerprintJS Pro React.
-  external List<String> get integrationInfo;
+  external JSArray<JSString> get integrationInfo;
 
   /// Region of the FingerprintJS service server
   external String? get region;
   external set region(String? region);
 
   /// Your custom API endpoint for getting visitor data.
-  external List<String>? get endpoint;
-  external set endpoint(List<String>? endpoint);
+  external JSArray<JSString>? get endpoint;
+  external set endpoint(JSArray<JSString>? endpoint);
 
   /// A JS agent script URL pattern.
   ///
@@ -224,17 +206,15 @@ class FingerprintJSOptions {
   /// - <version> — the major version of JS agent;
   /// - <apiKey> — the public key set via the `apiKey` option;
   /// - <loaderVersion> — the version of this package;
-  external List<String>? get scriptUrlPattern;
-  external set scriptUrlPattern(List<String>? scriptUrlPattern);
+  external JSArray<JSString>? get scriptUrlPattern;
+  external set scriptUrlPattern(JSArray<JSString>? scriptUrlPattern);
 
   external factory FingerprintJSOptions(
-      {String apiKey, List<String> integrationInfo});
+      {String apiKey, JSArray<JSString> integrationInfo});
 }
 
 /// Options of getting a visitor identifier.
-@JS()
-@anonymous
-class FingerprintJSGetOptions {
+extension type FingerprintJSGetOptions._(JSObject _) implements JSObject {
   /// `Tag` is a user-provided value or object that will be returned back to you in a webhook message.
   /// You may want to use the `tag` value to be able to associate a server-side webhook event with a web request of the
   /// current visitor.
@@ -242,7 +222,7 @@ class FingerprintJSGetOptions {
   /// What values can be used as a `tag`?
   /// Anything that identifies a visitor or a request.
   /// You can pass the requestId as a `tag` and then get this requestId back in the webhook, associated with a visitorId.
-  external Map<String, dynamic>? get tag;
+  external JSObject? get tag;
 
   /// `linkedId` is a way of linking current identification event with a custom identifier.
   /// This can be helpful to be able to filter API visit information later.
@@ -257,16 +237,11 @@ class FingerprintJSGetOptions {
   external int? get timeout;
 
   external factory FingerprintJSGetOptions(
-      {Object? tag,
-      String? linkedId,
-      int? timeout,
-      bool extendedResult = false});
+      {JSObject? tag, String? linkedId, int? timeout, bool extendedResult});
 }
 
 /// Interop for JS Agent exceptions
-@JS()
-@anonymous
-class WebException {
+extension type WebException._(JSObject _) implements JSObject {
   external String get message;
   external String? get requestId;
 }

--- a/lib/result.dart
+++ b/lib/result.dart
@@ -18,19 +18,16 @@ class FingerprintJSProResponse {
   /// base64. The field will miss if Sealed Results are disabled or unavailable for another reason.
   final String? sealedResult;
 
+  /// Default constructor
+  FingerprintJSProResponse(
+      this.requestId, this.visitorId, this.confidenceScore, this.sealedResult);
+
   /// Creates class instance from JSON Object
   /// that can be returned by Android or iOS agent, or can be a serialization result
   FingerprintJSProResponse.fromJson(Map<String, dynamic> json, this.requestId,
       num confidence, this.sealedResult)
       : visitorId = json['visitorId'],
         confidenceScore = ConfidenceScore(confidence);
-
-  /// Creates class instance from JavaScript object
-  FingerprintJSProResponse.fromJsObject(dynamic jsObject)
-      : visitorId = jsObject.visitorId,
-        requestId = jsObject.requestId,
-        confidenceScore = ConfidenceScore(jsObject.confidence.score),
-        sealedResult = jsObject.sealedResult;
 
   /// Serialize instance to JSON Object
   Map toJson() {
@@ -79,6 +76,21 @@ class FingerprintJSProExtendedResponse extends FingerprintJSProResponse {
   /// When the visitor was seen previous time
   final StSeenAt lastSeenAt;
 
+  /// Default constructor
+  FingerprintJSProExtendedResponse(
+      super.requestId,
+      super.visitorId,
+      super.confidenceScore,
+      super.sealedResult,
+      this.visitorFound,
+      this.ipAddress,
+      this.ipLocation,
+      this.osName,
+      this.osVersion,
+      this.device,
+      this.firstSeenAt,
+      this.lastSeenAt);
+
   /// Creates class instance from JSON Object
   /// that can be returned by Android or iOS agent, or can be a serialization result
   FingerprintJSProExtendedResponse.fromJson(
@@ -96,20 +108,6 @@ class FingerprintJSProExtendedResponse extends FingerprintJSProResponse {
         lastSeenAt =
             StSeenAt.fromJson(Map<String, dynamic>.from(json['lastSeenAt'])),
         super.fromJson();
-
-  /// Creates class instance from JavaScript object
-  FingerprintJSProExtendedResponse.fromJsObject(super.jsObject)
-      : visitorFound = jsObject.visitorFound,
-        ipAddress = jsObject.ip,
-        ipLocation = jsObject.ipLocation
-            ? IpLocation.fromJsObject(jsObject.ipLocation)
-            : null,
-        osName = jsObject.os,
-        osVersion = jsObject.osVersion,
-        device = jsObject.device,
-        firstSeenAt = StSeenAt.fromJsObject(jsObject.firstSeenAt),
-        lastSeenAt = StSeenAt.fromJsObject(jsObject.lastSeenAt),
-        super.fromJsObject();
 
   /// Serialize instance to JSON Object
   @override
@@ -136,6 +134,7 @@ class ConfidenceScore {
   /// The higher the number, the higher the chance of the visitor identifier to be true.
   final num score;
 
+  /// Default constructor
   ConfidenceScore(this.score);
 
   /// Serialize instance to JSON Object
@@ -184,6 +183,18 @@ class IpLocation {
   /// When not empty, can contain only top-level administrative units within a country, e.g. a state.
   final List<Subdivision>? subdivisions;
 
+  /// Default constructor
+  IpLocation(
+      this.accuracyRadius,
+      this.latitude,
+      this.longitude,
+      this.postalCode,
+      this.timezone,
+      this.city,
+      this.country,
+      this.continent,
+      this.subdivisions);
+
   /// Creates class instance from JSON Object
   /// that can be returned by Android or iOS agent, or can be a serialization result
   IpLocation.fromJson(Map<String, dynamic> json)
@@ -206,19 +217,6 @@ class IpLocation {
                 (subdivision) => Subdivision.fromJson(
                     Map<String, dynamic>.from(subdivision))))
             : null;
-
-  /// Creates class instance from JavaScript object
-  IpLocation.fromJsObject(dynamic jsObject)
-      : accuracyRadius = jsObject.accuracyRadius,
-        latitude = jsObject.latitude,
-        longitude = jsObject.longitude,
-        postalCode = jsObject.postalCode,
-        timezone = jsObject.timezone,
-        city = City.fromJsObject(jsObject.city),
-        country = Country.fromJsObject(jsObject.country),
-        continent = Continent.fromJsObject(jsObject.continent),
-        subdivisions = List<Subdivision>.from((jsObject.subdivisions as List)
-            .map((subdivision) => Subdivision.fromJsObject(subdivision)));
 
   /// Serialize instance to JSON Object
   Map toJson() {
@@ -245,12 +243,12 @@ class IpLocation {
 class City {
   final String name;
 
+  /// Default constructor
+  City(this.name);
+
   /// Creates class instance from JSON Object
   /// that can be returned by Android or iOS agent, or can be a serialization result
   City.fromJson(Map<String, dynamic> json) : name = json['name'];
-
-  /// Creates class instance from JavaScript object
-  City.fromJsObject(dynamic jsObject) : name = jsObject.name;
 
   /// Serialize instance to JSON Object
   Map toJson() {
@@ -267,16 +265,14 @@ class Country {
   final String code;
   final String name;
 
+  /// Default constructor
+  Country(this.code, this.name);
+
   /// Creates class instance from JSON Object
   /// that can be returned by Android or iOS agent, or can be a serialization result
   Country.fromJson(Map<String, dynamic> json)
       : code = json['code'],
         name = json['name'];
-
-  /// Creates class instance from JavaScript object
-  Country.fromJsObject(dynamic jsObject)
-      : code = jsObject.code,
-        name = jsObject.name;
 
   /// Serialize instance to JSON Object
   Map toJson() {
@@ -294,16 +290,14 @@ class Continent {
   final String code;
   final String name;
 
+  /// Default constructor
+  Continent(this.code, this.name);
+
   /// Creates class instance from JSON Object
   /// that can be returned by Android or iOS agent, or can be a serialization result
   Continent.fromJson(Map<String, dynamic> json)
       : code = json['code'],
         name = json['name'];
-
-  /// Creates class instance from JavaScript object
-  Continent.fromJsObject(dynamic jsObject)
-      : code = jsObject.code,
-        name = jsObject.name;
 
   /// Serialize instance to JSON Object
   Map toJson() {
@@ -322,16 +316,14 @@ class Subdivision {
   final String isoCode;
   final String name;
 
+  /// Default constructor
+  Subdivision(this.isoCode, this.name);
+
   /// Creates class instance from JSON Object
   /// that can be returned by Android or iOS agent, or can be a serialization result
   Subdivision.fromJson(Map<String, dynamic> json)
       : isoCode = json['isoCode'],
         name = json['name'];
-
-  /// Creates class instance from JavaScript object
-  Subdivision.fromJsObject(dynamic jsObject)
-      : isoCode = jsObject.isoCode,
-        name = jsObject.name;
 
   /// Serialize instance to JSON Object
   Map toJson() {
@@ -349,16 +341,14 @@ class StSeenAt {
   final String? global;
   final String? subscription;
 
+  /// Default constructor
+  StSeenAt(this.global, this.subscription);
+
   /// Creates class instance from JSON Object
   /// that can be returned by Android or iOS agent, or can be a serialization result
   StSeenAt.fromJson(Map<String, dynamic> json)
       : global = json['global'],
         subscription = json['subscription'];
-
-  /// Creates class instance from JavaScript object
-  StSeenAt.fromJsObject(dynamic jsObject)
-      : global = jsObject.global,
-        subscription = jsObject.subscription;
 
   /// Serialize instance to JSON Object
   Map toJson() {

--- a/lib/web_result.dart
+++ b/lib/web_result.dart
@@ -1,0 +1,108 @@
+import 'dart:js_interop';
+
+import 'js_agent_interop.dart';
+import 'result.dart';
+
+extension FingerprintJSProResponseWeb on FingerprintJSProResponse {
+  /// Creates class instance from JavaScript object
+  static FingerprintJSProResponse fromJsObject(IdentificationResult jsObject) {
+    return FingerprintJSProResponse(
+      jsObject.requestId,
+      jsObject.visitorId,
+      ConfidenceScore(jsObject.confidence.score),
+      jsObject.sealedResult,
+    );
+  }
+}
+
+extension FingerprintJSProExtendedResponseWeb
+    on FingerprintJSProExtendedResponse {
+  /// Creates class instance from JavaScript object
+  static FingerprintJSProExtendedResponse fromJsObject(
+      IdentificationExtendedResult jsObject) {
+    return FingerprintJSProExtendedResponse(
+      jsObject.requestId,
+      jsObject.visitorId,
+      ConfidenceScore(jsObject.confidence.score),
+      jsObject.sealedResult,
+      jsObject.visitorFound,
+      jsObject.ip,
+      IpLocationWeb.fromJsObject(jsObject.ipLocation),
+      jsObject.os,
+      jsObject.osVersion,
+      jsObject.device,
+      StSeenAtWeb.fromJsObject(jsObject.firstSeenAt),
+      StSeenAtWeb.fromJsObject(jsObject.lastSeenAt),
+    );
+  }
+}
+
+extension IpLocationWeb on IpLocation {
+  /// Creates class instance from JavaScript object
+  static IpLocation? fromJsObject(IdentificationResultIpLocation? jsObject) {
+    if (jsObject == null) {
+      return null;
+    }
+    return IpLocation(
+      jsObject.accuracyRadius,
+      jsObject.latitude,
+      jsObject.longitude,
+      jsObject.postalCode,
+      jsObject.timezone,
+      CityWeb.fromJsObject(jsObject.city),
+      CountryWeb.fromJsObject(jsObject.country),
+      ContinentWeb.fromJsObject(jsObject.continent),
+      jsObject.subdivisions != null
+          ? List<Subdivision>.from((jsObject.subdivisions!.toDart)
+              .map((subdivision) => SubdivisionWeb.fromJsObject(subdivision)))
+          : null,
+    );
+  }
+}
+
+extension CityWeb on City {
+  /// Creates class instance from JavaScript object
+  static City? fromJsObject(IdentificationResultCity? jsObject) {
+    if (jsObject == null) {
+      return null;
+    }
+    return City(jsObject.name);
+  }
+}
+
+extension CountryWeb on Country {
+  /// Creates class instance from JavaScript object
+  static Country? fromJsObject(IdentificationResultCountry? jsObject) {
+    if (jsObject == null) {
+      return null;
+    }
+    return Country(jsObject.code, jsObject.name);
+  }
+}
+
+extension ContinentWeb on Continent {
+  /// Creates class instance from JavaScript object
+  static Continent? fromJsObject(IdentificationResultContinent? jsObject) {
+    if (jsObject == null) {
+      return null;
+    }
+    return Continent(jsObject.code, jsObject.name);
+  }
+}
+
+extension SubdivisionWeb on Subdivision {
+  /// Creates class instance from JavaScript object
+  static Subdivision? fromJsObject(IdentificationResultSubdivision? jsObject) {
+    if (jsObject == null) {
+      return null;
+    }
+    return Subdivision(jsObject.isoCode, jsObject.name);
+  }
+}
+
+extension StSeenAtWeb on StSeenAt {
+  /// Creates class instance from JavaScript object
+  static StSeenAt fromJsObject(IdentificationResultStSeenAt jsObject) {
+    return StSeenAt(jsObject.global, jsObject.subscription);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://fingerprint.com
 repository: https://github.com/fingerprintjs/fingerprintjs-pro-flutter
 
 environment:
-  sdk: ">=3.1.0 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
   flutter: ">=2.5.0"
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  js: ^0.7.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/fingerprintjs/fingerprintjs-pro-flutter
 
 environment:
   sdk: ">=3.3.0 <4.0.0"
-  flutter: ">=2.5.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Motivation
This PR changes for using Web platform how we use interop between JS and Dart code.
- [The old approach](https://dart.dev/interop/js-interop/past-js-interop) was deprecated in Dart v3.7
- The new way is described [here](https://dart.dev/interop/js-interop/usage). In general allows to have better types in the border between Dart and JS world and introduces such types as `JSObject`, `JSArray,` and `JSPromise` that make code more clear and have methods to convert JS types to Dart types.

## What was made
- interop types
  - **classes** with `@JS` and `@anonymous` annotations were replaced with **extensions**
  - `Object` type was replaced with `JSObject`
  - `Array` type was replaced with `JSArray`
  -  `Future` type was replaced with `JSPromise`
- code
  - `promiseToFuture` was replaced with calling `.toDart` for `JSPromise`
  - `fromJsObject` **constructor** was replaced with **extension** with `fromJsObject` method. The reasons for it: we need to have a correct type for `jsObject` instead of dynamic (or `dart2js` compiler will treeshake fields getters). If we import the correct type from `js_agent_interop.dart` then `dart:js_interop` will be imported to the mobile builds and they will crash. So we need to have `fromJsObject` in a separate file that we will import only to the web endpoint (`fpjs_pro_plugin_web.dart`). The most efficient way that I found is to use an extension.
  - As a result, I had to change the minimal versions for Dart (3.3) (extension types) and Flutter (3.13) (uses minimum Dart 3.3).

## What could go wrong?
- js interop code could be occasionally imported to the mobile builds, it will just cause compilation error for iOS and Android platforms
- I edited `result.dart` with shared models for all platforms, but it should affect only the Web platform
- I change the deserialization for the web platform, but the good news is that I use well-described types instead of `dynamic`. 
- Web platform should be tested for both compilers (more information about compilers below)

## How to build the project for Web
Flutter has [3 ways](https://docs.flutter.dev/testing/build-modes) to run the app. For Web platform it is important to know that there are 2 compilers:
- [dartdevc](https://dart.dev/tools/dartdevc) - used for dev build to have a simple way to debug an app `flutter run`
- [dart2js](https://dart.dev/tools/dart2js) - used for production build to have the most optimized JS code `flutter run --release` and `flutter run --profile`