### PR TITLE
Externalize Fingerprint Native SDK Version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,5 @@
+apply from: 'fingerprint.gradle'
+
 group 'com.fingerprintjs.flutter.fpjs_pro.fpjs_pro_plugin'
 version '3.3.2'
 
@@ -53,5 +55,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.fingerprint.android:pro:[2.7.0, 3.0.0)"
+    implementation "com.fingerprint.android:pro:$fingerprint_native_sdk_version"
 }

--- a/android/fingerprint.gradle
+++ b/android/fingerprint.gradle
@@ -1,0 +1,8 @@
+ext.fingerprint_native_sdk_version = "[2.7.0, 3.0.0)"
+
+task printFingerprintNativeSDKVersion {
+    doLast {
+        println "${fingerprint_native_sdk_version}"
+    }
+}
+


### PR DESCRIPTION
This PR refactors the Android build setup by externalizing the Fingerprint Native SDK version and applying an external `fingerprint.gradle` Gradle script to keep changes in a single file.

**Changes:**
- Moved the Fingerprint Native SDK version to a variable `fingerprint_native_sdk_version` for easier access.
- Applied an external Gradle script (`fingerprint.gradle`) to centralize Fingerprint SDK changes.
- Created `printFingerprintNativeSDKVersion` gradle task to output the current Fingerprint Native SDK version identifier.
