### PR TITLE
Integrate `semantic-release-native-dependency-plugin-inter-1123`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,5 +18,6 @@ jobs:
       language: flutter
       language-version: '3.x'
       appId: ${{ vars.APP_ID }}
+      semantic-release-extra-plugins: '@fingerprintjs/semantic-release-native-dependency-plugin@^1.0.0'
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,5 +19,6 @@ jobs:
       language-version: '3.x'
       appId: ${{ vars.APP_ID }}
       semantic-release-extra-plugins: '@fingerprintjs/semantic-release-native-dependency-plugin@^1.0.0'
+      prepare-command: 'echo "flutter.sdk=$FLUTTER_ROOT" > $GITHUB_WORKSPACE/android/local.properties'
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.releaserc
+++ b/.releaserc
@@ -42,6 +42,21 @@
         "message": "chore(release): ${nextRelease.version} \\n\\n${nextRelease.notes}"
       }
     ],
-    "@semantic-release/github"
+    "@semantic-release/github",
+    [
+      "@fingerprintjs/semantic-release-native-dependency-plugin",
+      {
+        "iOS": {
+          "podSpecJsonPath": "ios/fpjs_pro_plugin.podspec.json",
+          "dependencyName": "FingerprintPro",
+          "displayName": "Fingerprint iOS SDK"
+        },
+        "android": {
+          "path": "android",
+          "gradleTaskName": "printFingerprintNativeSDKVersion",
+          "displayName": "Fingerprint Android SDK"
+        }
+      }
+    ],
   ]
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,9 +1,9 @@
-apply from: 'fingerprint.gradle'
-
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
 }
+
+apply from: 'fingerprint.gradle'
 
 group 'com.fingerprintjs.flutter.fpjs_pro.fpjs_pro_plugin'
 version '3.3.2'


### PR DESCRIPTION
This pull request introduces/integrates the `@fingerprintjs/semantic-release-native-dependency-plugin` to resolving native dependency versions for iOS and Android SDKs during the release process. I added the plugin configuration to the `.releaserc` file to handle native dependencies.

---

Related Task: INTER-1123