### PR TITLE
INTER-1209: Upgrade semantic-release-native-dependency-plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       language: flutter
       language-version: '3.x'
       appId: ${{ vars.APP_ID }}
-      semantic-release-extra-plugins: '@fingerprintjs/semantic-release-native-dependency-plugin@^1.0.0'
+      semantic-release-extra-plugins: '@fingerprintjs/semantic-release-native-dependency-plugin@^1.1.0'
       prepare-command: 'echo "flutter.sdk=$FLUTTER_ROOT" > $GITHUB_WORKSPACE/android/local.properties'
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.releaserc
+++ b/.releaserc
@@ -46,15 +46,18 @@
     [
       "@fingerprintjs/semantic-release-native-dependency-plugin",
       {
-        "iOS": {
-          "podSpecJsonPath": "ios/fpjs_pro_plugin.podspec.json",
-          "dependencyName": "FingerprintPro",
-          "displayName": "Fingerprint iOS SDK"
-        },
-        "android": {
-          "path": "android",
-          "gradleTaskName": "printFingerprintNativeSDKVersion",
-          "displayName": "Fingerprint Android SDK"
+        "heading": "Supported Native SDK Version Range",
+        "platforms": {
+          "iOS": {
+            "podSpecJsonPath": "ios/fpjs_pro_plugin.podspec.json",
+            "dependencyName": "FingerprintPro",
+            "displayName": "Fingerprint iOS SDK"
+          },
+          "android": {
+            "path": "android",
+            "gradleTaskName": "printFingerprintNativeSDKVersion",
+            "displayName": "Fingerprint Android SDK"
+          }
         }
       }
     ],


### PR DESCRIPTION
This PR upgrades the `@fingerprintjs/semantic-release-native-dependency-plugin` to version `1.1.0` and updates the `.releaserc` configuration.

## ✅ What's Changed?

- Bumped the plugin version from `^1.0.0` to `^1.1.0` in GitHub workflows extra plugin list.
- Added a new `heading` field in the plugin configuration.
- Refactored the platform configuration to use the new `platforms` key.

## 🤔 Why?

`v1.1` introduces support for customizing the release notes with a heading. Better readability for generated release notes.
