### PR TITLE
Add new inputs to analyze-commits workflow call

### DIFF
--- a/.github/workflows/lint_commit_messages.yaml
+++ b/.github/workflows/lint_commit_messages.yaml
@@ -12,6 +12,6 @@ jobs:
     with:
       language: 'flutter'
       language-version: '3.x'
-      prepareCommand: 'sudo gem install -n /usr/local/bin cocoapods'
+      prepareCommand: 'sudo gem install -n /usr/local/bin cocoapods && echo "flutter.sdk=$FLUTTER_ROOT" > $GITHUB_WORKSPACE/android/local.properties'
       semanticReleasePlugins: |
         @fingerprintjs/semantic-release-native-dependency-plugin@^1.2.1

--- a/.github/workflows/lint_commit_messages.yaml
+++ b/.github/workflows/lint_commit_messages.yaml
@@ -9,3 +9,9 @@ jobs:
   analyze-commits:
     name: Generate docs and coverage report
     uses: fingerprintjs/dx-team-toolkit/.github/workflows/analyze-commits.yml@v1
+    with:
+      language: 'flutter'
+      language-version: '3.x'
+      prepareCommand: 'sudo gem install -n /usr/local/bin cocoapods'
+      semanticReleasePlugins: |
+        @fingerprintjs/semantic-release-native-dependency-plugin@^1.2.1


### PR DESCRIPTION
Adds a custom `prepareCommand` to install CocoaPods, setup language params, also add native dependency plugin to the extra semantic release plugin list for generate preview.

Related-Task: INTER-1238