### PR TITLE
Fix lint commit messages workflow inputs of referenced workflow

### DIFF
--- a/.github/workflows/lint_commit_messages.yaml
+++ b/.github/workflows/lint_commit_messages.yaml
@@ -10,8 +10,8 @@ jobs:
     name: Generate docs and coverage report
     uses: fingerprintjs/dx-team-toolkit/.github/workflows/analyze-commits.yml@v1
     with:
-      language: 'flutter'
-      language-version: '3.x'
+      setupLanguage: 'flutter'
+      setupLanguageVersion: '3.x'
       prepareCommand: 'sudo gem install -n /usr/local/bin cocoapods && echo "flutter.sdk=$FLUTTER_ROOT" > $GITHUB_WORKSPACE/android/local.properties'
       semanticReleasePlugins: |
         @fingerprintjs/semantic-release-native-dependency-plugin@^1.2.1


### PR DESCRIPTION
Fixes typo on referenced workflow inputs. `language` -> `setupLanguage`, `language-version` -> `setupLanguageVersion`.  [Reference](https://github.com/fingerprintjs/dx-team-toolkit/blob/v1/.github/workflows/analyze-commits.yml#L25-L41)