### PR TITLE
INTER-2223: Upgrade `actions/checkout` to `v7`

### DIFF
--- a/.github/workflows/build-and-run-check-workflow.yml
+++ b/.github/workflows/build-and-run-check-workflow.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install and set Flutter version
         uses: subosito/flutter-action@0c3f14223a08fa950c8a4c00bcfb834e65744135
         with:

--- a/.github/workflows/build-and-run-check-workflow.yml
+++ b/.github/workflows/build-and-run-check-workflow.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Install and set Flutter version
         uses: subosito/flutter-action@0c3f14223a08fa950c8a4c00bcfb834e65744135
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       # This action adds a token needed for pub.dev
       - name: Install Dart
         uses: dart-lang/setup-dart@v1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       # This action adds a token needed for pub.dev
       - name: Install Dart
         uses: dart-lang/setup-dart@v1


### PR DESCRIPTION
Node.js 20 is deprecated on GitHub Actions runners and will be removed on September 16, 2026. `actions/checkout@v7` (actually v5+) uses Node.js 24 internally, resolving the deprecation warning in the `Build and run checks` workflow (`release`) step.

> [!NOTE]
> The branch name says `v5`, but that's cosmetic and not worth a rename/re-create PR at this point.