### PR TITLE
INTER-2224: Upgrade `subosito/flutter-action` to `v2.23.0`

### DIFF
--- a/.github/workflows/build-and-run-check-workflow.yml
+++ b/.github/workflows/build-and-run-check-workflow.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install and set Flutter version
-        uses: subosito/flutter-action@0c3f14223a08fa950c8a4c00bcfb834e65744135
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: 'stable'
       - name: Restore packages

--- a/.github/workflows/build-and-run-check-workflow.yml
+++ b/.github/workflows/build-and-run-check-workflow.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install and set Flutter version
-        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 #v2.23.0
         with:
           channel: 'stable'
       - name: Restore packages

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           sdk: stable
       - name: Install and set Flutter version
-        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 #v2.23.0
         with:
           channel: 'stable'
       - name: Publish to pub.dev

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           sdk: stable
       - name: Install and set Flutter version
-        uses: subosito/flutter-action@1c5eb12d812966ca84680edc38353a0851c8fd56
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: 'stable'
       - name: Publish to pub.dev


### PR DESCRIPTION
Updates `subosito/flutter-action` to [`v2.23.0`](https://github.com/subosito/flutter-action/releases/tag/v2.23.0) in workflow files.

## Notable Changes from v2.4.0 to v2.23.0

| Version | Highlight |
|---------|-----------|
| v2.23.0 | FVM (Flutter Version Manager) support; separate `pub-cache` boolean flag; simplified zip extraction |
| v2.22.0 | Upgrade `actions/cache` to v5; remove deprecated macOS Intel runner from CI |
| v2.21.0 | Cache hit outputs; dynamic `PUB-CACHE-PATH` support |
| v2.20.0 | Conditional `yq` install on Windows; env var handling improvements |
| v2.19.0 | Architecture-based test splitting; `PUB-CACHE-PATH` output consistency fix |
| v2.18.0 | Auto-install `yq` on Windows; git source support |
| v2.16.0 | New `dry-run` option (retrieve outputs without downloading Flutter) |
| v2.15.0 | `flutter-version-file` option to centralize version via `pubspec.yaml` |
| v2.13.0 | Auto-detect runner architecture; caching improvements |
| v2.12.0 | Fix script permissions and temp dir on macOS hosted runners |
| v2.11.0 | Allow git references as version numbers on master channel |
| v2.10.0 | Re-add master channel |
| v2.9.0 | ⚠️  **Breaking:** Drop master channel, remove v-prefix requirement; full codebase rewrite |
| v2.8.0 | Replace deprecated `set-output` with `$GITHUB_OUTPUT` |
| v2.7.0 | Support action outputs |
| v2.6.0 | Dynamic `cache-path` support |
| v2.5.0 | Dynamic `cache-key` support |