### PR TITLE
ci: update publish workflow trigger to use release events

### DIFF
--- a/.changeset/gentle-eagles-attend.md
+++ b/.changeset/gentle-eagles-attend.md
@@ -1,0 +1,5 @@
+---
+"fingerprintjs-pro-flutter": patch
+---
+
+Update publish workflow to run whenever release is published

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,9 +1,9 @@
 name: Publish to pub.dev
 
 on:
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
+  release:
+    types:
+      - published
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Updated `publish.yaml` to trigger whenever release is published - it's easier to maintain than relaying on tag format.

Added a new changest to trigger new pre-release; it will be removed before doing a stable one.