### PR TITLE
chore: remove pnpm-workspace.yaml

### DIFF
--- a/.changeset/six-corners-change.md
+++ b/.changeset/six-corners-change.md
@@ -1,0 +1,5 @@
+---
+"fingerprintjs-pro-flutter": patch
+---
+
+Restore old tag format

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ name: Publish to pub.dev
 on:
   push:
     tags:
-      - 'fingerprintjs-pro-flutter@[0-9]+.[0-9]+.[0-9]+*'
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
   workflow_dispatch:
 
 jobs:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,0 @@
-packages:
-  - '.'
-minimumReleaseAgeExclude:
-  - '@fingerprintjs/changesets-native-dependency-format@0.1.0'


### PR DESCRIPTION
Removed pnpm-workspace.yaml - this should force changesets to no longer treat this project as monorepo and use simpler tag format.