### PR TITLE
chore: exit pre-release mode and fix changeset preview

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "test",
   "initialVersions": {
     "fingerprintjs-pro-flutter": "4.12.0"

--- a/.github/workflows/lint_commit_messages.yaml
+++ b/.github/workflows/lint_commit_messages.yaml
@@ -24,6 +24,8 @@ jobs:
     with:
       pr-title: ${{ github.event.pull_request.title }}
       changeset-command: 'pnpm exec changeset'
+      setupLanguage: 'flutter'
+      setupLanguageVersion: '3.x'
       prepare-command: |
         sudo gem install -n /usr/local/bin cocoapods
         pod --version

--- a/.github/workflows/lint_commit_messages.yaml
+++ b/.github/workflows/lint_commit_messages.yaml
@@ -11,12 +11,6 @@ jobs:
     uses: fingerprintjs/dx-team-toolkit/.github/workflows/analyze-commits.yml@v1
     with:
       previewNotes: false
-      setupLanguage: 'flutter'
-      setupLanguageVersion: '3.x'
-      prepareCommand: |
-        sudo gem install -n /usr/local/bin cocoapods
-        pod --version
-        echo "flutter.sdk=$FLUTTER_ROOT" > $GITHUB_WORKSPACE/android/local.properties
 
   preview-changeset:
     name: Preview changeset


### PR DESCRIPTION
- Exit Changesets prerelease mode so the next release is stable `4.13.0`.
- Set up Flutter for the changeset preview job so native SDK version ranges show in the PR comment.
- Drop unused Flutter/CocoaPods setup from commit analysis (`previewNotes` is already false).