### PR TITLE
fix: resolve FingerprintJS WASM JS interop (#137)

### DIFF
--- a/lib/fpjs_pro_plugin_web.dart
+++ b/lib/fpjs_pro_plugin_web.dart
@@ -64,24 +64,23 @@ class FpjsProPluginWeb {
   static Future<void> initFpjs(MethodCall call) async {
     final options = FingerprintJSOptions(
       apiKey: call.arguments['apiToken'],
-      integrationInfo: [
-        "fingerprint-pro-flutter/${call.arguments['pluginVersion']}/web"
-      ] as JSArray<JSString>,
+      integrationInfo: _toJSStringArray(
+          ["fingerprint-pro-flutter/${call.arguments['pluginVersion']}/web"]),
     );
     if (call.arguments['region'] != null) {
       options.region = call.arguments['region'];
     }
     if (call.arguments['endpoint'] != null) {
-      options.endpoint = [
+      options.endpoint = _toJSStringArray([
         call.arguments['endpoint'],
-        ...(call.arguments['endpointFallbacks'] ?? [])
-      ] as JSArray<JSString>;
+        ...List<String>.from(call.arguments['endpointFallbacks'] ?? [])
+      ]);
     }
     if (call.arguments['scriptUrlPattern'] != null) {
-      options.scriptUrlPattern = [
+      options.scriptUrlPattern = _toJSStringArray([
         call.arguments['scriptUrlPattern'],
-        ...(call.arguments['scriptUrlPatternFallbacks'] ?? [])
-      ] as JSArray<JSString>;
+        ...List<String>.from(call.arguments['scriptUrlPatternFallbacks'] ?? [])
+      ]);
     }
     try {
       _fpPromise = FingerprintJS.load(options).toDart;
@@ -157,6 +156,9 @@ class FpjsProPluginWeb {
     }
   }
 }
+
+JSArray<JSString> _toJSStringArray(List<String> values) =>
+    values.map((value) => value.toJS).toList().toJS;
 
 // `isA<WebException>()` needs Dart >=3.4; this package supports >=3.3.
 FingerprintProError _wrapJsAgentError(Object error) {


### PR DESCRIPTION
## Summary

Fix WASM incompatibility caused by invalid Dart-to-JavaScript interop
casts in `fpjs_pro_plugin`.

Flutter's WASM dry run currently reports:

> invalid_runtime_check_with_js_interop_types

and running the application results in:

> Type 'List<String>' is not a subtype of type 'JSValue' in type cast

This prevents the plugin from working correctly with Flutter WebAssembly.

## Related issue

Closes #137

## Testing

- `flutter build web --wasm --release`
- Verified the WASM build no longer reports the JS interop cast errors.