### PR TITLE
ci: skip changeset preview on fork PRs

### DIFF
--- a/.github/workflows/lint_commit_messages.yaml
+++ b/.github/workflows/lint_commit_messages.yaml
@@ -14,6 +14,9 @@ jobs:
 
   preview-changeset:
     name: Preview changeset
+    # Fork PRs get a read-only token, so the preview comment 403s.
+    # https://docs.github.com/en/actions/tutorials/authenticate-with-github_token#permissions-for-the-github_token
+    if: github.event.pull_request.head.repo.full_name == github.repository
     uses: fingerprintjs/dx-team-toolkit/.github/workflows/preview-changeset-release.yml@v1
     with:
       pr-title: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
- Skip `preview-changeset` when the PR comes from a fork, so the comment job does not 403.

### Discussion point: not `pull_request_target`

That event would get a write token, but this job checks out the PR and runs `pnpm exec changeset`. Running fork code with write access is unsafe. Fork PRs skip the preview comment; same-repo PRs still get it. Posting previews on forks is tracked in [dx-team-toolkit#202](https://github.com/fingerprintjs/dx-team-toolkit/issues/202).

### Context

Seen on [PR #141](https://github.com/fingerprintjs/fingerprintjs-pro-flutter/pull/141): `Resource not accessible by integration` on create comment.